### PR TITLE
Config/#4: 프로젝트 내부에서 사용할 색, 전역 스타일 적용

### DIFF
--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,10 +1,13 @@
+import { ThemeProvider } from '@styles/index.ts';
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 
 import App from './App.tsx';
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
-  // <React.StrictMode>
-  <App />,
-  // </React.StrictMode>
+  <React.StrictMode>
+    <ThemeProvider>
+      <App />
+    </ThemeProvider>
+  </React.StrictMode>,
 );

--- a/src/styles/ThemeProvider/index.tsx
+++ b/src/styles/ThemeProvider/index.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { ThemeProvider as GlobalThemeProvider } from 'styled-components';
+
+import { GlobalStyle, THEME } from '..';
+
+interface ThemeProviderProps {
+  children: React.ReactNode;
+}
+
+const ThemeProvider = ({ children }: ThemeProviderProps) => {
+  return (
+    <GlobalThemeProvider theme={THEME}>
+      <GlobalStyle />
+      {children}
+    </GlobalThemeProvider>
+  );
+};
+
+export default ThemeProvider;

--- a/src/styles/global/global.ts
+++ b/src/styles/global/global.ts
@@ -1,0 +1,137 @@
+import { createGlobalStyle } from 'styled-components';
+
+const GlobalStyle = createGlobalStyle`
+  html,
+  body,
+  div,
+  span,
+  applet,
+  object,
+  iframe,
+  h1,
+  h2,
+  h3,
+  h4,
+  h5,
+  h6,
+  p,
+  blockquote,
+  pre,
+  a,
+  abbr,
+  acronym,
+  address,
+  big,
+  cite,
+  code,
+  del,
+  dfn,
+  em,
+  img,
+  ins,
+  kbd,
+  q,
+  s,
+  samp,
+  small,
+  strike,
+  strong,
+  sub,
+  sup,
+  tt,
+  var,
+  b,
+  u,
+  i,
+  center,
+  dl,
+  dt,
+  dd,
+  ol,
+  ul,
+  li,
+  fieldset,
+  form,
+  label,
+  legend,
+  table,
+  caption,
+  tbody,
+  tfoot,
+  thead,
+  tr,
+  th,
+  td,
+  article,
+  aside,
+  canvas,
+  details,
+  embed,
+  figure,
+  figcaption,
+  footer,
+  header,
+  hgroup,
+  menu,
+  nav,
+  output,
+  ruby,
+  section,
+  summary,
+  time,
+  mark,
+  audio,
+  video {
+    margin: 0;
+    padding: 0;
+    border: 0;
+    font-size: 100%;
+    font: inherit;
+    vertical-align: baseline;
+  }
+  article,
+  aside,
+  details,
+  figcaption,
+  figure,
+  footer,
+  header,
+  hgroup,
+  menu,
+  nav,
+  section {
+    display: block;
+  }
+  * {
+    user-select: none;
+  }
+  body {
+    max-width: 480px;
+    min-height: 100vh;
+    margin: 0 auto;
+  }
+  ol,
+  ul {
+    list-style: none;
+  }
+  blockquote,
+  q {
+    quotes: none;
+  }
+  blockquote:before,
+  blockquote:after,
+  q:before,
+  q:after {
+    content: '';
+    content: none;
+  }
+  table {
+    border-collapse: collapse;
+    border-spacing: 0;
+  }
+  button {
+    border: none;
+  }
+`;
+
+export default GlobalStyle;

--- a/src/styles/index.ts
+++ b/src/styles/index.ts
@@ -1,0 +1,3 @@
+export { default as GlobalStyle } from './global/global';
+export { default as THEME } from './theme/theme';
+export { default as ThemeProvider } from './ThemeProvider';

--- a/src/styles/styled.d.ts
+++ b/src/styles/styled.d.ts
@@ -1,0 +1,28 @@
+import 'styled-components';
+
+declare module 'styled-components' {
+  export interface DefaultTheme {
+    BACK_GROUND: {
+      INPUT_PAGE: string;
+      RESULT_PAGE: string;
+    };
+    DROPDOWN: {
+      SELECT_BOX: string;
+    };
+    TEXT: {
+      BLACK: string;
+      GRAY: string;
+      BALLOON: string;
+    };
+    BUTTON: {
+      WHITE: string;
+      BROWN: string;
+      BLACK: string;
+      SHADOW: string;
+    };
+    PAGE: {
+      ACTIVE: string;
+      INACTIVE: string;
+    };
+  }
+}

--- a/src/styles/theme/theme.ts
+++ b/src/styles/theme/theme.ts
@@ -1,0 +1,28 @@
+import { DefaultTheme } from 'styled-components';
+
+const THEME: DefaultTheme = {
+  BACK_GROUND: {
+    INPUT_PAGE: '#C1EBF9',
+    RESULT_PAGE: '#7F4C2F',
+  },
+  DROPDOWN: {
+    SELECT_BOX: '#F1FCFF',
+  },
+  TEXT: {
+    BLACK: '#191919',
+    GRAY: '#C7C7C7',
+    BALLOON: '#333333',
+  },
+  BUTTON: {
+    WHITE: '#FFFFFF',
+    BROWN: '#7F4C2F',
+    BLACK: '#333333',
+    SHADOW: '#FFBB00',
+  },
+  PAGE: {
+    ACTIVE: '#0E0E0E',
+    INACTIVE: '#FFFFFF',
+  },
+};
+
+export default THEME;


### PR DESCRIPTION
## 👨🏻‍🏫 개요

- closes : #4 
- 프로젝트 내부에서 사용할 색, 전역 스타일 적용했어요

## 🐥 설명
- 프로젝트 내부에서 사용할 색
  - 피그마 보고 일단 우선적으로 개발해야 할 컴포넌트들에서 사용할 색들을 설정해뒀어요
```ts
const THEME: DefaultTheme = {
  BACK_GROUND: {
    INPUT_PAGE: '#C1EBF9',
    RESULT_PAGE: '#7F4C2F',
  },
  //...
};
```
![code](https://github.com/PKNU-Capstone/titmetable_front/assets/68489467/67e4fc86-43a0-473a-9554-19b351d4a0fc)
- `styled-components` 는 CSS-in-JS라서 props를 넘겨받아서 사용할 수 있어요.
- `ThemeProvider`로 감싸진 컴포넌트들은 모두 동일한 theme props를 받아서 사용할 수 있어요.
- 컴포넌트를 개발 할 때, 색깔을 사용해야 하는 경우라면 위의 예시 처럼 사용하면 돼요!

## 📷 스크린샷 (Optional)
